### PR TITLE
Remove exclusions list to index all buckets, even the meta-buckets

### DIFF
--- a/src/ScoopSearch.Indexer.Tests/GitHub/GitHubClientTests.cs
+++ b/src/ScoopSearch.Indexer.Tests/GitHub/GitHubClientTests.cs
@@ -158,35 +158,18 @@ public class GitHubClientTests : IClassFixture<HostFixture>
             .And.BeLessThan(900, "because there should be less than 900 results. If it returns more than 900, the date condition should be updated");
     }
 
-    [Theory]
-    [CombinatorialData]
-    public async void SendAsync_NonExistentUrl_Throws(bool followRedirects)
+    [Fact]
+    public async void SendAsync_NonExistentUrl_Throws()
     {
         // Arrange
         var uri = new Uri("http://example.invalid/foo/bar");
         var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, uri);
 
         // Act
-        Func<Task> act = () => _sut.SendAsync(httpRequestMessage, followRedirects, CancellationToken.None);
+        Func<Task> act = () => _sut.SendAsync(httpRequestMessage, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<HttpRequestException>();
-    }
-
-    [Theory]
-    [InlineData("https://github.com/okibcn/Bucket.git")]
-    [InlineData("https://github.com/01walid/it-scoop.git")]
-    public async void SendAsync_DontFollowRedirection_Succeeds(string input)
-    {
-        // Arrange
-        var uri = new Uri(input);
-        var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, uri);
-
-        // Act
-        var result = await _sut.SendAsync(httpRequestMessage, false, CancellationToken.None);
-
-        // Assert
-        result.Should().BeRedirection();
     }
 
     [Theory]
@@ -199,7 +182,7 @@ public class GitHubClientTests : IClassFixture<HostFixture>
         var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, uri);
 
         // Act
-        var result = await _sut.SendAsync(httpRequestMessage, true, CancellationToken.None);
+        var result = await _sut.SendAsync(httpRequestMessage, CancellationToken.None);
 
         // Assert
         result.Should().BeSuccessful();

--- a/src/ScoopSearch.Indexer.Tests/Processor/FetchBucketsProcessorTests.cs
+++ b/src/ScoopSearch.Indexer.Tests/Processor/FetchBucketsProcessorTests.cs
@@ -47,7 +47,6 @@ public class FetchBucketsProcessorTests : IClassFixture<HostFixture>
         _logger.Should().Log(LogLevel.Information, _ => Regex.IsMatch(_, $"Found {expectedOfficialBucketsCount} official buckets.+"));
         _logger.Should().Log(LogLevel.Information, _ => Regex.IsMatch(_, @"Found \d{4} buckets on GitHub"));
         _logger.Should().Log(LogLevel.Information, _ => Regex.IsMatch(_, @"Found \d+ buckets to ignore \(appsettings\.json\)"));
-        _logger.Should().Log(LogLevel.Information, _ => Regex.IsMatch(_, @"Found \d+ buckets to ignore from external list.+"));
         _logger.Should().Log(LogLevel.Information, _ => Regex.IsMatch(_, @"Found \d+ buckets to add \(appsettings\.json\)"));
         _logger.Should().Log(LogLevel.Information, _ => Regex.IsMatch(_, @"Found \d+ buckets to add from external list.+"));
         _logger.Should().Log(LogLevel.Debug, _ => _.StartsWith("Adding bucket"), Times.AtLeast(expectedAtLeastBucketsCount));

--- a/src/ScoopSearch.Indexer/Configuration/BucketsOptions.cs
+++ b/src/ScoopSearch.Indexer/Configuration/BucketsOptions.cs
@@ -10,8 +10,6 @@ public class BucketsOptions
 
     public HashSet<Uri> IgnoredBuckets { get; set; } = new HashSet<Uri>();
 
-    public Uri IgnoredBucketsListUrl { get; set; } = null!;
-
     public HashSet<Uri> ManualBuckets { get; set; } = new HashSet<Uri>();
 
     public Uri ManualBucketsListUrl { get; set; } = null!;

--- a/src/ScoopSearch.Indexer/Constants.cs
+++ b/src/ScoopSearch.Indexer/Constants.cs
@@ -3,5 +3,4 @@ namespace ScoopSearch.Indexer;
 internal static class Constants
 {
     public const string GitHubHttpClientName = "GitHub";
-    public const string GitHubHttpClientNoRedirectName = "GitHubNoRedirect";
 }

--- a/src/ScoopSearch.Indexer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ScoopSearch.Indexer/Extensions/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ namespace ScoopSearch.Indexer.Extensions;
 
 internal static class ServiceCollectionExtensions
 {
-    public static IHttpClientBuilder AddHttpClient(this IServiceCollection services, string name, bool followAutoRedirect)
+    public static IHttpClientBuilder AddGitHubHttpClient(this IServiceCollection services, string name)
     {
         return services
             .AddHttpClient(name, (serviceProvider, client) =>
@@ -26,7 +26,6 @@ internal static class ServiceCollectionExtensions
                 var gitHubOptions = serviceProvider.GetRequiredService<IOptions<GitHubOptions>>();
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", gitHubOptions.Value.Token);
             })
-            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler() { AllowAutoRedirect = followAutoRedirect })
             .AddPolicyHandler((provider, _) => CreateRetryPolicy(provider, name));
     }
 

--- a/src/ScoopSearch.Indexer/GitHub/GitHubClient.cs
+++ b/src/ScoopSearch.Indexer/GitHub/GitHubClient.cs
@@ -10,12 +10,10 @@ internal class GitHubClient : IGitHubClient
     private const int ResultsPerPage = 100;
 
     private readonly HttpClient _githubHttpClient;
-    private readonly HttpClient _githubHttpClientNoRedirect;
 
     public GitHubClient(IHttpClientFactory httpClientFactory)
     {
         _githubHttpClient = httpClientFactory.CreateClient(Constants.GitHubHttpClientName);
-        _githubHttpClientNoRedirect = httpClientFactory.CreateClient(Constants.GitHubHttpClientNoRedirectName);
     }
 
     public async Task<string> GetAsStringAsync(Uri uri, CancellationToken cancellationToken)
@@ -29,9 +27,9 @@ internal class GitHubClient : IGitHubClient
         }
     }
 
-    public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool followRedirects, CancellationToken cancellationToken)
+    public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        return (followRedirects ? _githubHttpClient : _githubHttpClientNoRedirect).SendAsync(request, cancellationToken);
+        return _githubHttpClient.SendAsync(request, cancellationToken);
     }
 
     public async Task<GitHubRepo?> GetRepositoryAsync(Uri uri, CancellationToken cancellationToken)

--- a/src/ScoopSearch.Indexer/GitHub/IGitHubClient.cs
+++ b/src/ScoopSearch.Indexer/GitHub/IGitHubClient.cs
@@ -4,7 +4,7 @@ public interface IGitHubClient
 {
     Task<string> GetAsStringAsync(Uri uri, CancellationToken cancellationToken);
 
-    Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool followRedirects, CancellationToken cancellationToken);
+    Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
 
     Task<GitHubRepo?> GetRepositoryAsync(Uri uri, CancellationToken cancellationToken);
 

--- a/src/ScoopSearch.Indexer/ServicesExtensions.cs
+++ b/src/ScoopSearch.Indexer/ServicesExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using ScoopSearch.Indexer.Configuration;
 using ScoopSearch.Indexer.Extensions;
 using ScoopSearch.Indexer.Git;
@@ -27,8 +26,7 @@ public static class ServicesExtensions
             .Configure<IConfiguration>((options, configuration) => configuration.GetRequiredSection(GitHubOptions.Key).Bind(options));
 
         // Services
-        @this.AddHttpClient(Constants.GitHubHttpClientName, true);
-        @this.AddHttpClient(Constants.GitHubHttpClientNoRedirectName, false);
+        @this.AddGitHubHttpClient(Constants.GitHubHttpClientName);
         @this.AddSingleton<IGitRepositoryProvider, GitRepositoryProvider>();
         @this.AddSingleton<IGitHubClient, GitHubClient>();
         @this.AddSingleton<ISearchClient, AzureSearchClient>();

--- a/src/ScoopSearch.Indexer/appsettings.json
+++ b/src/ScoopSearch.Indexer/appsettings.json
@@ -32,8 +32,6 @@
             "https://github.com/rasa/scoop-directory"
         ],
 
-        "IgnoredBucketsListUrl": "https://raw.githubusercontent.com/rasa/scoop-directory/master/exclude.txt",
-
         "ManualBuckets": [
         ],
 


### PR DESCRIPTION
With the introduction of the new ["Distinct manifests only"](https://github.com/ScoopInstaller/scoopinstaller.github.io/issues/58), we can now index all the manifests, even the meta-buckets.
Related to https://github.com/ScoopInstaller/Scoop/discussions/5440