### PR TITLE
Use keepalive-workflow to keep workflows running even if there is no activity on the repo

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -52,3 +52,12 @@ jobs:
         with:
           name: logs
           path: ${{ env.OUTPUT_PATH }}/output.txt
+
+  keepalive:
+    name: Keepalive Workflow
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,3 +59,12 @@ jobs:
       run: |
         export JAVA_HOME=$JAVA_HOME_17_X64 # Force JAVA_HOME environment variable (Version 11 or 17 is required by SonarScanner)
         dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+
+  keepalive:
+    name: Keepalive Workflow
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
https://github.com/ScoopInstaller/scoopinstaller.github.io/issues/88